### PR TITLE
Fix page build failed

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -5,7 +5,7 @@
 
   <body>
 
-  <div class="container"
+  <div class="container">
     {% include header.html %}
 
     <div class="page-content">


### PR DESCRIPTION
The Jekyll pages failed to build the because of a missing angle bracket in `app/_layout/default.html` introduced in #2.

See error receive via email:

```
The page build failed with the following error:

A file was included in `./app/_layouts/default.html` that is a symlink or does not exist in your `_includes` directory. For more information, see https://help.github.com/articles/page-build-failed-file-is-a-symlink.

If you have any questions please contact us at https://github.com/contact.
```
